### PR TITLE
Move tsdx to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "tslib": "^1.10.0",
-    "typescript": "^3.7.3"
+    "typescript": "^3.7.3",
+    "tsdx": "^0.13.2"
   },
   "dependencies": {
     "@babel/generator": "^7.7.7",
@@ -46,8 +47,7 @@
     "babel-template": "^6.26.0",
     "babel-traverse": "^6.26.0",
     "babel-types": "^6.26.0",
-    "babylon": "^6.18.0",
-    "tsdx": "^0.13.2"
+    "babylon": "^6.18.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi there :wave:

Firstly, thanks for this plugin, man. It helps a ton!

---

TSDX has tons of dependencies which are not required in projects of babel-plugin-use-what-changed users. What's more, this can lead to dependency version clashes.

_Excerpt from my yarn.lock with a list of all dependencies from babel-plugin-use-what-changed_
```
"@simbathesailor/babel-plugin-use-what-changed@^0.1.15":
  version "0.1.17"
  resolved "https://registry.yarnpkg.com/@simbathesailor/babel-plugin-use-what-changed/-/babel-plugin-use-what-changed-0.1.17.tgz#ca7e9505df9d1e644d1af84c1f16f32c23f1f9f4"
  integrity sha512-YlygCsChGCgAnUhkQUwsSzaX/y71GAf0DGOa17fJ2/BZ1E5jboqoJ9peSb3YWl6MhGKJiNxhWz8kw7pEuZD7oA==
  dependencies:
    "@babel/generator" "^7.7.7"
    "@babel/types" "^7.7.4"
    "@types/babel-template" "^6.25.2"
    babel-template "^6.26.0"
    babel-traverse "^6.26.0"
    babel-types "^6.26.0"
    babylon "^6.18.0"
    tsdx "^0.13.2"

tsdx@^0.13.2:
  version "0.13.3"
  resolved "https://registry.yarnpkg.com/tsdx/-/tsdx-0.13.3.tgz#b8a23ed1cb06f1d00bfd0f541f5d3cac90b611f5"
  integrity sha512-IzEzSygWpGC/E6UQ1rPxRRpeRLPQ3RBSmisTcX2p9PKFItrwG50MaW8DfVDIolkk4Xt9cYUfgjJ+g01qN2gMYQ==
  dependencies:
    "@babel/core" "^7.4.4"
    "@babel/helper-module-imports" "^7.0.0"
    "@babel/plugin-proposal-class-properties" "^7.4.4"
    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.7.4"
    "@babel/plugin-proposal-optional-chaining" "^7.7.5"
    "@babel/plugin-syntax-dynamic-import" "^7.2.0"
    "@babel/plugin-transform-regenerator" "^7.4.5"
    "@babel/plugin-transform-runtime" "^7.6.0"
    "@babel/polyfill" "^7.4.4"
    "@babel/preset-env" "^7.4.4"
    "@rollup/plugin-commonjs" "^11.0.0"
    "@rollup/plugin-json" "^4.0.0"
    "@rollup/plugin-node-resolve" "^7.1.0"
    "@rollup/plugin-replace" "^2.2.1"
    "@types/jest" "^24.0.15"
    "@typescript-eslint/eslint-plugin" "^2.12.0"
    "@typescript-eslint/parser" "^2.12.0"
    ansi-escapes "^4.2.1"
    asyncro "^3.0.0"
    babel-eslint "^10.0.3"
    babel-plugin-annotate-pure-calls "^0.4.0"
    babel-plugin-dev-expression "^0.2.1"
    babel-plugin-macros "^2.6.1"
    babel-plugin-transform-async-to-promises "^0.8.14"
    babel-plugin-transform-rename-import "^2.3.0"
    babel-traverse "^6.26.0"
    babylon "^6.18.0"
    camelcase "^5.2.0"
    chalk "^2.4.2"
    enquirer "^2.3.4"
    eslint "^6.1.0"
    eslint-config-prettier "^6.0.0"
    eslint-config-react-app "^5.0.2"
    eslint-plugin-flowtype "^3.13.0"
    eslint-plugin-import "^2.18.2"
    eslint-plugin-jsx-a11y "^6.2.3"
    eslint-plugin-prettier "^3.1.0"
    eslint-plugin-react "^7.14.3"
    eslint-plugin-react-hooks "^2.2.0"
    execa "3.2.0"
    fs-extra "^8.0.1"
    jest "^24.8.0"
    jest-watch-typeahead "^0.4.0"
    jpjs "^1.2.1"
    lodash.merge "^4.6.2"
    ora "^3.4.0"
    pascal-case "^2.0.1"
    prettier "^1.19.1"
    progress-estimator "^0.2.2"
    rollup "^1.32.1"
    rollup-plugin-babel "^4.3.2"
    rollup-plugin-sourcemaps "^0.4.2"
    rollup-plugin-terser "^5.1.2"
    rollup-plugin-typescript2 "^0.26.0"
    sade "^1.4.2"
    semver "^7.1.1"
    shelljs "^0.8.3"
    tiny-glob "^0.2.6"
    ts-jest "^24.0.2"
    tslib "^1.9.3"
    typescript "^3.7.3"
```